### PR TITLE
Fix bug in focus module when no client is currently focused 

### DIFF
--- a/focus.lua
+++ b/focus.lua
@@ -187,7 +187,7 @@ local function bydirection(dir, c, swap,max)
           local old_src = capi.client.focus and capi.client.focus.screen
           capi.client.focus = cltbl[((not cl and #cltbl == 1) and 1 or target)]
           capi.client.focus:raise()
-          if old_src and capi.client.focus.screen ~= capi.screen[old_src] then
+          if not old_src or capi.client.focus.screen ~= capi.screen[old_src] then
             capi.mouse.coords(capi.client.focus:geometry())
           end
         end

--- a/init.lua
+++ b/init.lua
@@ -154,26 +154,26 @@ local function new(k)
   -- This have to be executer after rc.lua
   glib.idle_add(glib.PRIORITY_DEFAULT_IDLE, function()
     for k,v in pairs(keys) do
-      for _,key_nane in ipairs(v) do
-        aw[#aw+1] = awful.key({ "Mod4",                              }, key_nane, function () module.focus (k          ) end,
-                              { description = "Change focus to the "..key_nane, group = "Collision" })
-        aw[#aw+1] = awful.key({ "Mod4", "Mod1"                       }, key_nane, function () module.resize(k          ) end,
-                              { description = "Resize to the "..key_nane, group = "Collision" })
-        aw[#aw+1] = awful.key({ "Mod4", "Shift"                      }, key_nane, function () module.move  (k          ) end,
-                              { description = "Move to the "..key_nane, group = "Collision" })
-        aw[#aw+1] = awful.key({ "Mod4", "Shift",   "Control"         }, key_nane, function () module.move  (k,nil ,true) end,
+      for _,key_name in ipairs(v) do
+        aw[#aw+1] = awful.key({ "Mod4",                              }, key_name, function () module.focus (k          ) end,
+                              { description = "Change focus to the "..key_name, group = "Collision" })
+        aw[#aw+1] = awful.key({ "Mod4", "Mod1"                       }, key_name, function () module.resize(k          ) end,
+                              { description = "Resize to the "..key_name, group = "Collision" })
+        aw[#aw+1] = awful.key({ "Mod4", "Shift"                      }, key_name, function () module.move  (k          ) end,
+                              { description = "Move to the "..key_name, group = "Collision" })
+        aw[#aw+1] = awful.key({ "Mod4", "Shift",   "Control"         }, key_name, function () module.move  (k,nil ,true) end,
                               { description = "", group = "Collision" })
-        aw[#aw+1] = awful.key({ "Mod4",            "Control"         }, key_nane, function () module.focus (k,nil ,true) end,
-                              { description = "Change floating focus to the "..key_nane, group = "Collision" })
-        aw[#aw+1] = awful.key({ "Mod4", "Mod1" ,   "Control"         }, key_nane, function () module.screen(k          ) end,
-                              { description = "Change screen to the "..key_nane, group = "Collision" })
-          aw[#aw+1] = awful.key({ "Mod1", "Shift", "Control", "Mod4" }, key_nane, function () module.screen(k,true     ) end,
-                                { description = "Move tag screen to the "..key_nane, group = "Collision" })
+        aw[#aw+1] = awful.key({ "Mod4",            "Control"         }, key_name, function () module.focus (k,nil ,true) end,
+                              { description = "Change floating focus to the "..key_name, group = "Collision" })
+        aw[#aw+1] = awful.key({ "Mod4", "Mod1" ,   "Control"         }, key_name, function () module.screen(k          ) end,
+                              { description = "Change screen to the "..key_name, group = "Collision" })
+        aw[#aw+1] = awful.key({ "Mod1", "Shift", "Control", "Mod4" }, key_name, function () module.screen(k,true     ) end,
+                              { description = "Move tag screen to the "..key_name, group = "Collision" })
         if k == "left" or k =="right" then -- Conflict with my text editor, so I say no
-          aw[#aw+1] = awful.key({ "Mod1",          "Control"         }, key_nane, function () module.tag   (k,nil ,true) end,
-                                { description = "Select tag to the "..key_nane, group = "Collision" })
-          aw[#aw+1] = awful.key({ "Mod1", "Shift", "Control"         }, key_nane, function () module.tag   (k,true,true) end,
-                                { description = "Move tag to the "..key_nane, group = "Collision" })
+          aw[#aw+1] = awful.key({ "Mod1",          "Control"         }, key_name, function () module.tag   (k,nil ,true) end,
+                                { description = "Select tag to the "..key_name, group = "Collision" })
+          aw[#aw+1] = awful.key({ "Mod1", "Shift", "Control"         }, key_name, function () module.tag   (k,true,true) end,
+                                { description = "Move tag to the "..key_name, group = "Collision" })
         end
       end
     end


### PR DESCRIPTION
- Suppose we have 2 screens side-by-side and the mouse is at the
screen 1 (left) and no client is open/focused there, and the user
requests to move focus to the client at right (screen 2). Currently
the focus is moved correctly, but the mouse stays in the screen one,
leading to kinda inconsistence for the next commands, etc.
- This patch modifies the focus.bydirection() to move mouse to new
client's screen (we're moving focus to) even when there was no client
focused at that point